### PR TITLE
Salto Deployment: 2 Deployments

### DIFF
--- a/force-app/main/default/classes/LeftBClass.cls
+++ b/force-app/main/default/classes/LeftBClass.cls
@@ -1,5 +1,6 @@
 public with sharing class LeftBClass {
     public LeftBClass() {
 // 20250122-005301
+// 20250124-072320
     }
 }

--- a/force-app/main/default/classes/RightClass.cls
+++ b/force-app/main/default/classes/RightClass.cls
@@ -1,5 +1,5 @@
 public with sharing class RightClass {
-    
+    // 20250124-072334
     public RightClass() {
 
         RightAClass rightA = new RightAClass();

--- a/force-app/main/default/objects/Lead/fields/GWR_Cactus1__c.field-meta.xml
+++ b/force-app/main/default/objects/Lead/fields/GWR_Cactus1__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>GWR_Cactus1__c</fullName>
+    <type>Date</type>
+    <required>false</required>
+    <label>GWR Cactus1</label>
+    <trackFeedHistory>false</trackFeedHistory>
+</CustomField>


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/21a05c49-f2d7-4fba-a617-849b7195bd0a/envs/f9af1e16-daca-4ebb-bbbc-0d1424f727e1/deployments/692e8527-09f5-4337-9de3-47f15523de9e) from 2 previous deployments to SF SIT to SF UAT.
Deployer: Geoffrey Routledge (geoffrey.routledge@salto.io)
This deployment was created from the following Pull Request: https://github.com/workingman/gwr-sfdx-2501b/pull/20 (2ce08ba)

Promoted deployments:
[BAM-105 targets for dropin function](https://app.salto.io/orgs/21a05c49-f2d7-4fba-a617-849b7195bd0a/envs/f9af1e16-daca-4ebb-bbbc-0d1424f727e1/deployments/7a34f3fd-8023-49d9-88b1-a05ef9cd33ca)
[BAM-73 Cactus fields](https://app.salto.io/orgs/21a05c49-f2d7-4fba-a617-849b7195bd0a/envs/f9af1e16-daca-4ebb-bbbc-0d1424f727e1/deployments/f68be72b-2bf4-48a0-bb8e-8f9465eae35e)
